### PR TITLE
feat: Add bottom navigation bar

### DIFF
--- a/app/src/main/java/com/bhaswat/toolshare/core/BottomNavigationBar.kt
+++ b/app/src/main/java/com/bhaswat/toolshare/core/BottomNavigationBar.kt
@@ -1,0 +1,63 @@
+package com.bhaswat.toolshare.core
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+data class BottomNavItem(
+    val name: String,
+    val route: String,
+    val icon: ImageVector
+)
+
+@Composable
+fun BottomNavigationBar(navController: NavController) {
+    val items = listOf(
+        BottomNavItem("Community", "community", Icons.Default.Home),
+        BottomNavItem("Lending", "lending", Icons.Default.Add),
+        BottomNavItem("Wishlist", "wishlist", Icons.Default.Favorite),
+        BottomNavItem("Sustainability", "sustainability", Icons.Default.Star),
+        BottomNavItem("Profile", "profile", Icons.Default.Person)
+    )
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+
+    NavigationBar {
+        items.forEach { item ->
+            NavigationBarItem(
+                icon = { Icon(item.icon, contentDescription = item.name) },
+                label = { Text(item.name) },
+                selected = currentRoute == item.route,
+                onClick = {
+                    navController.navigate(item.route) {
+                        // Pop up to the start destination of the graph to
+                        // avoid building up a large stack of destinations
+                        // on the back stack as users select items
+                        navController.graph.startDestinationRoute?.let { route ->
+                            popUpTo(route) {
+                                saveState = true
+                            }
+                        }
+                        // Avoid multiple copies of the same destination when
+                        // reselecting the same item
+                        launchSingleTop = true
+                        // Restore state when reselecting a previously selected item
+                        restoreState = true
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/bhaswat/toolshare/core/Navigation.kt
+++ b/app/src/main/java/com/bhaswat/toolshare/core/Navigation.kt
@@ -1,8 +1,13 @@
 package com.bhaswat.toolshare.core
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.bhaswat.toolshare.authentication.AuthScreen
 import com.bhaswat.toolshare.authentication.SignUpScreen
@@ -16,14 +21,29 @@ import com.bhaswat.toolshare.wishlist.WishlistScreen
 @Composable
 fun AppNavigation() {
     val navController = rememberNavController()
-    NavHost(navController = navController, startDestination = "login") {
-        composable("login") { AuthScreen(navController) }
-        composable("signup") { SignUpScreen(navController) }
-        composable("community") { CommunityScreen() }
-        composable("lending") { LendingScreen() }
-        composable("notifications") { NotificationsScreen() }
-        composable("profile") { ProfileScreen() }
-        composable("sustainability") { SustainabilityScreen() }
-        composable("wishlist") { WishlistScreen() }
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+
+    Scaffold(
+        bottomBar = {
+            if (currentRoute !in listOf("login", "signup")) {
+                BottomNavigationBar(navController)
+            }
+        }
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = "login",
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            composable("login") { AuthScreen(navController) }
+            composable("signup") { SignUpScreen(navController) }
+            composable("community") { CommunityScreen() }
+            composable("lending") { LendingScreen() }
+            composable("notifications") { NotificationsScreen() }
+            composable("profile") { ProfileScreen() }
+            composable("sustainability") { SustainabilityScreen() }
+            composable("wishlist") { WishlistScreen() }
+        }
     }
 }


### PR DESCRIPTION
This commit adds a bottom navigation bar to the app, providing access to the community, lending, wishlist, sustainability, and profile screens.

The bottom navigation bar is implemented as a separate composable and integrated into the main navigation graph using a `Scaffold`. The navigation bar is hidden on the login and sign-up screens.